### PR TITLE
feat(AI):support IPFS WASM MCP tools

### DIFF
--- a/config/mcp_manifest.yaml
+++ b/config/mcp_manifest.yaml
@@ -5,6 +5,14 @@ server_config:
   max_connections: 100
   timeout: 30s
 
+ipfs:
+  enable: true  # Set to true to enable IPFS support
+  lassie_net:
+    scheme: "http"  # http or https
+    host: "127.0.0.1"
+    port: 31999
+  cids: []  # Optional list of pre-loaded CIDs
+
 llm_config:
   base_url: ""  # Optional base URL for API endpoints
   provider: "openai"  # Default provider
@@ -18,7 +26,8 @@ llm_config:
 # Defines WASM modules and their exposed MCP tools
 modules:
   - name: "hello"
-    wasm_path: "/home/corerman/ICODE/IceFireLabs/dANP-Engine/config/hello.wasm"  # Supports file:// or IPFS:// schemes
+    #wasm_path: "file:///home/corerman/ICODE/IceFireLabs/dANP-Engine/config/hello.wasm"  # Supports file:// or IPFS:// schemes
+    wasm_path: "IPFS://QmeDsaLTc8dAfPrQ5duC4j5KqPdGbcinEo5htDqSgU8u8Z"  # Supports file:// or IPFS:// schemes
     tools:
       - name: "say_hello"
         description: "Greet someone by name"


### PR DESCRIPTION
This PR implements protocol-based WASM module loading with support for:
- Local files via `file://` protocol
- IPFS-hosted modules via `IPFS://` protocol
- Maintains backward compatibility with direct paths

Key changes:
1. Added IPFS configuration section to mcp_manifest.yaml
2. Updated wasm.go to handle protocol prefixes:
   - Parses and strips file:// prefix for local files
   - Extracts CID from IPFS:// prefix and uses IPFS client
   - Falls back to direct path handling for backward compatibility
3. Updated example config to use file:// protocol
